### PR TITLE
wr-112: on articles page articles/feed should be open by default

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -5,6 +5,7 @@ import { createRoot } from 'react-dom/client';
 
 import {
   App,
+  Navigate,
   ProtectedRoute,
   PublicRoute,
   RouterProvider,
@@ -79,6 +80,10 @@ createRoot(document.querySelector('#root') as HTMLElement).render(
                   {
                     path: ArticleSubRoute.MY_ARTICLES,
                     element: <MyArticles />,
+                  },
+                  {
+                    index: true,
+                    element: <Navigate to={ArticleSubRoute.FEED} />,
                   },
                 ],
               },


### PR DESCRIPTION
Current behavior:
When you open articles page - it shows empty page with tabs
Expected behavior:
When you open articles page /feed subroute should be open by default