### PR TITLE
wr-51:  fix article card design bugs

### DIFF
--- a/backend/src/packages/articles/article.repository.ts
+++ b/backend/src/packages/articles/article.repository.ts
@@ -31,8 +31,8 @@ class ArticleRepository implements IRepository {
       .orderBy('articles.publishedAt', SortingOrder.DESCENDING)
       .withGraphJoined(this.defaultRelationExpression);
 
-    return articles.map((article) =>
-      ArticleEntity.initializeWithAuthor({
+    return articles.map((article) => {
+      return ArticleEntity.initializeWithAuthor({
         ...article,
         genre: article.genre.name,
         prompt: article.prompt
@@ -43,8 +43,8 @@ class ArticleRepository implements IRepository {
               prop: article.prompt.prop,
             }
           : null,
-      }),
-    );
+      });
+    });
   }
 
   public async find(id: number): Promise<ArticleEntity | null> {

--- a/frontend/src/pages/articles/components/article-card/article-card.tsx
+++ b/frontend/src/pages/articles/components/article-card/article-card.tsx
@@ -52,7 +52,7 @@ const ArticleCard: React.FC<Properties> = ({
           )}
           <span className={styles.publicationTime}>{MOCKED_READ_TIME}</span>
         </div>
-        <Icon iconName="favorite" className={styles.icon} />
+        <Icon iconName="favorite" className={styles.pointerIcon} />
       </div>
       <div className={styles.body}>
         <div className={styles.articleInfo}>
@@ -72,23 +72,23 @@ const ArticleCard: React.FC<Properties> = ({
       <div className={styles.footer}>
         <ul className={styles.reactions}>
           <li className={styles.reaction}>
-            <Icon iconName="comment" className={styles.reactionIcon} />
+            <Icon iconName="comment" className={styles.pointerIcon} />
             <span className={styles.reactionCount}>{comments}</span>
           </li>
           <li className={styles.reaction}>
-            <Icon iconName="view" className={styles.reactionIcon} />
+            <Icon iconName="view" />
             <span className={styles.reactionCount}>{views}</span>
           </li>
           <li className={styles.reaction}>
-            <Icon iconName="like" className={styles.reactionIcon} />
+            <Icon iconName="like" className={styles.pointerIcon} />
             <span className={styles.reactionCount}>{likes}</span>
           </li>
           <li className={styles.reaction}>
-            <Icon iconName="dislike" className={styles.reactionIcon} />
+            <Icon iconName="dislike" className={styles.pointerIcon} />
             <span className={styles.reactionCount}>{dislikes}</span>
           </li>
         </ul>
-        <Icon iconName="share" className={styles.icon} />
+        <Icon iconName="share" className={styles.pointerIcon} />
         <Link
           to={articleRouteById as typeof AppRoute.ARTICLE}
           className={styles.readMore}

--- a/frontend/src/pages/articles/components/article-card/styles.module.scss
+++ b/frontend/src/pages/articles/components/article-card/styles.module.scss
@@ -131,10 +131,6 @@
   gap: 5px;
 }
 
-.footer .reactionIcon {
-  cursor: pointer;
-}
-
 .footer .reactionCount {
   color: var(--dark-gray-50);
   font-weight: 400;
@@ -154,6 +150,6 @@
   line-height: normal;
 }
 
-.icon {
+.pointerIcon {
   cursor: pointer;
 }


### PR DESCRIPTION
Fixed:

1. Text is not properly spaced from the adjacent element and is directly attached to the hints block. Fixed by @AnastasiaR2 
2. The cursor pointer appears when hovering over the icon displaying the view count.
3. When the text in an article lacks spaces, it extends beyond the boundaries of the article card. Fixed by @AnastasiaR2 