### PR TITLE
wr-238: Modify the chart colors on Genres Stats

### DIFF
--- a/frontend/src/libs/components/prompt-generation/libs/components/prompt-card/styles.module.scss
+++ b/frontend/src/libs/components/prompt-generation/libs/components/prompt-card/styles.module.scss
@@ -10,7 +10,7 @@
 }
 
 .category {
-  width: fit-content;
+  width: 100px;
   height: 29px;
   margin: 0 auto;
   padding: 5px 9px;

--- a/frontend/src/pages/profile/components/user-articles-genres-stats/libs/constants/constants.ts
+++ b/frontend/src/pages/profile/components/user-articles-genres-stats/libs/constants/constants.ts
@@ -2,15 +2,15 @@ import { type ArticleGenreStatsFilters } from '~/packages/articles/articles.js';
 
 const GENRES_CHART_COLORS = [
   '#44996b',
-  '#58a77c',
-  '#6bb588',
-  '#7cc392',
-  '#8fd19c',
-  '#a1e0a6',
-  '#b4efb1',
-  '#c6fdc1',
-  '#d9fecb',
-  '#ecffd6',
+  '#6699CC',
+  '#996699',
+  '#CC9966',
+  '#66CC99',
+  '#CC99CC',
+  '#99CC66',
+  '#CC9999',
+  '#66CCCC',
+  '#8A8EAE',
   '#d6ecff',
 ];
 


### PR DESCRIPTION
1. Modified the chart colors on genres stats.
2. Updated prompt categories to be the same size.

![image_2023-09-26_19-05-10](https://github.com/BinaryStudioAcademy/bsa-2023-writorium/assets/85576361/65736972-6489-4aee-b56a-6395371991f9)
![image_2023-09-26_19-05-41](https://github.com/BinaryStudioAcademy/bsa-2023-writorium/assets/85576361/5888a7a6-efb5-434d-af63-fbe4c1aceba5)