### PR TITLE
wr-320: The prompts should be aligned with the text

### DIFF
--- a/frontend/src/libs/components/prompt-generation/styles.module.scss
+++ b/frontend/src/libs/components/prompt-generation/styles.module.scss
@@ -21,7 +21,8 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  gap: 20px;
+  gap: 30px;
+  max-width: 470px;
   list-style: none;
 }
 


### PR DESCRIPTION
 - [x] The prompts should be aligned with the text.

![image](https://github.com/BinaryStudioAcademy/bsa-2023-writorium/assets/90383315/9cc0be46-80e9-4e4f-a48e-e357179422ba)
