### PR TITLE
wr-446: Fix achievements modal heading color

### DIFF
--- a/frontend/src/pages/profile/components/user-achievements/styles.module.scss
+++ b/frontend/src/pages/profile/components/user-achievements/styles.module.scss
@@ -34,6 +34,10 @@
   color: var(--black-90);
 }
 
+.modalTitle {
+  color: var(--white);
+}
+
 .modal {
   overflow: hidden;
   box-shadow: 0 0 6px var(--translucent-dark-blue-gray);
@@ -97,12 +101,16 @@
       minmax(75px, 1fr)
     );
     gap: 10px;
-    padding: 5px;
+    padding: 10px 5px 5px;
     font-size: 10px;
   }
 
   .achievementBadgeModal {
     width: 75px;
     height: 75px;
+  }
+
+  .modalTitle {
+    font-size: 18px;
   }
 }

--- a/frontend/src/pages/profile/components/user-achievements/user-achievements.tsx
+++ b/frontend/src/pages/profile/components/user-achievements/user-achievements.tsx
@@ -71,7 +71,7 @@ const UserAchievements: React.FC<Properties> = ({ className }) => {
             closeBtnClassName={styles.modalCloseBtn}
           >
             <div>
-              <h2 className={styles.title}>Achievements</h2>
+              <h2 className={styles.modalTitle}>Achievements</h2>
               <AchievementList
                 hasToShowTooltip={true}
                 achievements={achievementsList}

--- a/frontend/src/pages/profile/styles.module.scss
+++ b/frontend/src/pages/profile/styles.module.scss
@@ -55,7 +55,7 @@
   }
 
   .latestArticles {
-    min-height: 414px;
+    min-height: 168px;
   }
 }
 


### PR DESCRIPTION
![image](https://github.com/BinaryStudioAcademy/bsa-2023-writorium/assets/90383315/6cc14bf0-7435-40e8-b35f-a069fef0ce52)

Added achievements modal title for narrow screens.
Also changed min-height for latest-articles section.
